### PR TITLE
Parameter ignore_ext in parseSOAP

### DIFF
--- a/pyzimbra/soap_soappy.py
+++ b/pyzimbra/soap_soappy.py
@@ -124,7 +124,7 @@ class ZimbraSOAPParser(SOAPpy.SOAPParser):
         SOAPpy.SOAPParser.endElementNS(self, name, qname)
 
 
-def parseSOAP(xml_str, rules = None):
+def parseSOAP(xml_str, rules = None, ignore_ext = None):
     """
     Replacement for SOAPpy._parseSOAP method to spoof SOAPParser.
     """


### PR DESCRIPTION
It's required after migration do Plone 4.3, and with new Zimbra. Parameter can be ignored by code, but we must allow send it. Can you add it to you repo? Thanks in advance!
